### PR TITLE
Add Support for AWS.Tools Modules

### DIFF
--- a/AWSSSOHelper.psd1
+++ b/AWSSSOHelper.psd1
@@ -55,7 +55,7 @@ PowerShellVersion = '6.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('AWSPowerShell.NetCore')
+RequiredModules = @()
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -1,5 +1,4 @@
 #Requires -PSEdition Core
-#Requires -Module AWSPowerShell.NetCore
 
 <#
 .SYNOPSIS
@@ -46,13 +45,6 @@ function Get-AWSSSORoleCredential {
         [int]$TimeoutInSeconds = 120,
         [string]$Path = (Join-Path $Home ".awsssohelper")
     )
-
-    try {
-        Get-DefaultAWSRegion
-    }
-    catch {
-        Import-Module AWSPowerShell.NetCore
-    }
 
     if ($Region) {
         Set-DefaultAWSRegion $Region

--- a/AWSSSOHelper.psm1
+++ b/AWSSSOHelper.psm1
@@ -46,6 +46,13 @@ function Get-AWSSSORoleCredential {
         [string]$Path = (Join-Path $Home ".awsssohelper")
     )
 
+    # Manually import the AWSPowerShell.NetCore module if present as it is not configured for auto-loading
+    $awsNetCorePowerShellModuleName = 'AWSPowerShell.NetCore'
+    if (Get-Module -Name $awsNetCorePowerShellModuleName -ListAvailable)
+    {
+        Import-Module -Name $awsNetCorePowerShellModuleName
+    }
+
     if ($Region) {
         Set-DefaultAWSRegion $Region
     }

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ A basic set of functionality is included, potential future enhancements could be
 - Default AWS Region configured (Set-DefaultAWSRegion)
 - Either the AWS PowerShell.NetCore or the required AWS.Tools PowerShell modules installed. See [What are the AWS Tools for PowerShell?](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-welcome.html) for information on the differences in the modules.
 
-### Install AWS PowerShell.NetCore Module
+#### Install AWS PowerShell.NetCore Module
 
 ```powershell
 Install-Module AWSPowerShell.NetCore -Force
 ```
 
-### Install AWS Tools Modules
+#### Install AWS Tools Modules
 
 ```powershell
 Install-Module AWS.Tools.Common, AWS.Tools.SSO, AWS.Tools.SSOOIDC -Force

--- a/README.md
+++ b/README.md
@@ -17,20 +17,37 @@ A basic set of functionality is included, potential future enhancements could be
 
 - PowerShell Core
 - Default AWS Region configured (Set-DefaultAWSRegion)
+- Either the AWS PowerShell.NetCore or the required AWS.Tools PowerShell modules installed. See [What are the AWS Tools for PowerShell?](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-welcome.html) for information on the differences in the modules.
+
+### Install AWS PowerShell.NetCore Module
+
+```powershell
+Install-Module AWSPowerShell.NetCore -Force
+```
+
+### Install AWS Tools Modules
+
+```powershell
+Install-Module AWS.Tools.Common, AWS.Tools.SSO, AWS.Tools.SSOOIDC -Force
+```
 
 ## Installation
 
-    Install-Module AWSSSOHelper -Force
+```powershell
+Install-Module AWSSSOHelper -Force
+```
 
 ## Usage
 
-    .EXAMPLE
-        Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start"
-    .EXAMPLE
-        Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
-    .EXAMPLE
-        $RoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -PassThru
-        Get-S3Bucket @RoleCredentials
-    .EXAMPLE
-        $AllRoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
-        $AllRoleCredentials | Foreach-Object { Get-S3Bucket -AccessKey $_.AccessKey -SecretKey $_.SecretKey -SessionToken $_.SessionToken }
+```powershell
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start"
+.EXAMPLE
+    Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
+.EXAMPLE
+    $RoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -PassThru
+    Get-S3Bucket @RoleCredentials
+.EXAMPLE
+    $AllRoleCredentials = Get-AWSSSORoleCredential -StartUrl "https://mycompany.awsapps.com/start" -AllAccountRoles
+    $AllRoleCredentials | Foreach-Object { Get-S3Bucket -AccessKey $_.AccessKey -SecretKey $_.SecretKey -SessionToken $_.SessionToken }
+```


### PR DESCRIPTION
This PR adds support for the `AWS.Tools` modules as well as for the legacy `AWSPowerShell.NetCore` module.